### PR TITLE
[MOBL-1648] Inbox message sorting is now customisable

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ android {
     }
 
     dependencies {
-        implementation 'com.blueshift:android-sdk-x:3.4.1'
+        implementation 'com.blueshift:android-sdk-x:3.4.2'
     }
 }

--- a/example/lib/pages/inbox_page.dart
+++ b/example/lib/pages/inbox_page.dart
@@ -18,13 +18,14 @@ class InboxPage extends StatelessWidget {
             },
           ),
         ),
-        body: const BlueshiftInbox(
+        body: BlueshiftInbox(
           // titleTextStyle: Theme.of(context).textTheme.bodyLarge,
           // detailsTextStyle: Theme.of(context).textTheme.bodyMedium,
           // dateTextStyle: Theme.of(context).textTheme.bodySmall,
           // unreadIndicatorColor: Colors.red,
           // dividerColor: Colors.blueGrey,
           // dateFormatter: (date) => date.toIso8601String(),
+          // sortMessages: (m1, m2) => m2.createdAt.compareTo(m1.createdAt),
           // placeholder: const Text("Inbox is empty!"),
           // loadingIndicator: const Icon(Icons.hourglass_top),
           // inboxItem: (msg) => Column(

--- a/lib/blueshift_inbox.dart
+++ b/lib/blueshift_inbox.dart
@@ -44,15 +44,13 @@ class _BlueshiftInboxState extends State<BlueshiftInbox> {
 
   void getInboxMessagesFromCache() {
     Blueshift.getInboxMessages().then((messages) {
-      messages.sort(
-        (a, b) {
-          if (widget.sortMessages != null) {
-            return widget.sortMessages!(a,b);
-          } else {
-            return b.createdAt.compareTo(a.createdAt);
-          }
-        },
-      );
+      if (widget.sortMessages != null) {
+        messages.sort((a, b) => widget.sortMessages!(a,b),);
+      } else {
+        if (Platform.isAndroid) {
+          messages.sort((a, b) => b.createdAt.compareTo(a.createdAt),);
+        }
+      }
 
       setState(() => _inboxMessages = messages);
     });

--- a/lib/blueshift_inbox.dart
+++ b/lib/blueshift_inbox.dart
@@ -15,6 +15,8 @@ class BlueshiftInbox extends StatefulWidget {
   final Widget? loadingIndicator;
   final Widget Function(BlueshiftInboxMessage)? inboxItem;
   final String Function(DateTime)? dateFormatter;
+  final int Function(BlueshiftInboxMessage, BlueshiftInboxMessage)?
+      sortMessages;
 
   const BlueshiftInbox({
     Key? key,
@@ -27,6 +29,7 @@ class BlueshiftInbox extends StatefulWidget {
     this.loadingIndicator = const CircularProgressIndicator(),
     this.inboxItem,
     this.dateFormatter,
+    this.sortMessages,
   }) : super(key: key);
 
   @override
@@ -41,6 +44,16 @@ class _BlueshiftInboxState extends State<BlueshiftInbox> {
 
   void getInboxMessagesFromCache() {
     Blueshift.getInboxMessages().then((messages) {
+      messages.sort(
+        (a, b) {
+          if (widget.sortMessages != null) {
+            return widget.sortMessages!(a,b);
+          } else {
+            return b.createdAt.compareTo(a.createdAt);
+          }
+        },
+      );
+
       setState(() => _inboxMessages = messages);
     });
   }


### PR DESCRIPTION
The messages in the inbox are now sorted in chronological order. The recent one will be at the top.

If the host app would like to override the sorting logic, they could provide a sorting function as below.

```dart
BlueshiftInbox(
  sortMessages: (m1, m2) => m2.createdAt.compareTo(m1.createdAt),
);
```